### PR TITLE
Pull rhel7 changes such as CODEOWNERS into rhel9

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,24 @@
+# default group
+* @pcdshub/epics-reviewers
+
+# language-specific group(s)
+## EPICS files
+*.archive @pcdshub/epics-reviewers
+*.autosave @pcdshub/epics-reviewers
+*.cmd @pcdshub/epics-reviewers
+*.db @pcdshub/epics-reviewers
+*.dbd @pcdshub/epics-reviewers
+*.edl @pcdshub/epics-reviewers
+*.ioc @pcdshub/epics-reviewers
+*.proto @pcdshub/epics-reviewers
+*.req @pcdshub/epics-reviewers
+*.sub-arch @pcdshub/epics-reviewers
+*.sub-req @pcdshub/epics-reviewers
+*.substitutions @pcdshub/epics-reviewers
+*.tpl-arch @pcdshub/epics-reviewers
+*.tpl-req @pcdshub/epics-reviewers
+RELEASE_SITE @pcdshub/epics-reviewers
+/configure/RELEASE @pcdshub/epics-reviewers
+
+# github folder holds administrative files
+.github/** @pcdshub/software-admin


### PR DESCRIPTION
rhel9 will become the new default branch, so it needs the codeowners etc