### PR TITLE
Update to version of ev2_driver that works with rocky9

### DIFF
--- a/common/kernel-module-dirs.cmd
+++ b/common/kernel-module-dirs.cmd
@@ -26,7 +26,7 @@ then
 	then
 		EV2_VER=latest
 	fi
-	EV2_DRIVER=$EPICS_SITE_TOP/R3.14.12-0.4.0/modules/ev2_driver/$EV2_VER/
+	EV2_DRIVER=$EPICS_SITE_TOP/R7.0.3.1-2.0/modules/ev2_driver/$EV2_VER/
 fi
 export EV2_DRIVER
 


### PR DESCRIPTION
The latest version of ev2_driver under R3.14.12-0.4.0 does not support rocky9/rhel9. The latest version on R7.0.3.1-2.0 does. This is currently breaking daq machines that run rocky9 which have the ioc service.